### PR TITLE
Change graphql package to peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Make the `graohql` package a peer dependency. See [#18](https://github.com/dividab/gql-cache/pull/18).
+
 ## [0.5.0] - 2018-08-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -15,15 +15,16 @@
   ],
   "author": "Jonas Kello <jonas.kello@divid.se>",
   "license": "MIT",
-  "dependencies": {
-    "@types/graphql": "^0.13.0",
-    "graphql": "^0.13.0"
+  "peerDependencies": {
+    "graphql": "^0.13.0 || ^14.0.0",
+    "@types/graphql": "^0.13.0 || ^14.0.0"
   },
   "devDependencies": {
     "@types/benchmark": "^1.0.31",
     "@types/tape": "^4.2.32",
     "benchmark": "^2.1.4",
     "coveralls": "^3.0.1",
+    "graphql": "^0.13.2",
     "graphql-tag": "^2.9.2",
     "husky": "^0.14.3",
     "lint-staged": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/benchmark": "^1.0.31",
     "@types/tape": "^4.2.32",
+    "@types/graphql": "^0.13.0 || ^14.0.0",
     "benchmark": "^2.1.4",
     "coveralls": "^3.0.1",
     "graphql": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,10 +86,6 @@
   version "1.0.31"
   resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-1.0.31.tgz#2dd3514e93396f362ba5551a7c9ff0da405c1d38"
 
-"@types/graphql@^0.13.0":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.13.1.tgz#7d39750355c9ecb921816d6f76c080405b5f6bea"
-
 "@types/node@*":
   version "10.3.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.2.tgz#3840ec6c12556fdda6e0e6d036df853101d732a4"
@@ -831,7 +827,7 @@ graphql-tag@^2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
 
-graphql@^0.13.0:
+graphql@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:


### PR DESCRIPTION
According to this the graphql package should be a peerDependency and devDependency (to work when testing etc.):

https://medium.com/@leeb/graphql-js-preparing-for-v14-0-0-839f823c144e
