### PR TITLE
Return keys from denormalize

### DIFF
--- a/src/denormalize.ts
+++ b/src/denormalize.ts
@@ -45,7 +45,7 @@ export function denormalize(
   const response = {};
   let partial = false;
   let stale = false;
-  const keys: Array<string> = [];
+  const keys = new Set<string>();
   stack.push([rootFieldNode, "ROOT_QUERY", response, undefined]);
   while (stack.length > 0) {
     const [
@@ -84,7 +84,7 @@ export function denormalize(
         break;
       }
 
-      keys.push(key);
+      keys.add(key);
       const staleFields = staleMap[key];
 
       // If we've been here before we need to use the previously created response object
@@ -188,6 +188,6 @@ export function denormalize(
     partial,
     stale,
     data: !partial ? data : undefined,
-    keys
+    keys: Array.from(keys)
   };
 }

--- a/src/denormalize.ts
+++ b/src/denormalize.ts
@@ -45,6 +45,7 @@ export function denormalize(
   const response = {};
   let partial = false;
   let stale = false;
+  const keys: Array<string> = [];
   stack.push([rootFieldNode, "ROOT_QUERY", response, undefined]);
   while (stack.length > 0) {
     const [
@@ -73,9 +74,9 @@ export function denormalize(
     if (idOrIdArray === null) {
       responseObjectOrNewParentArray = null;
     } else if (!Array.isArray(idOrIdArray)) {
-      const id: NormKey = idOrIdArray as NormKey;
+      const key: NormKey = idOrIdArray as NormKey;
 
-      const normObj = normMap[id];
+      const normObj = normMap[key];
 
       // Does not exist in normalized map. We can't fully resolve query
       if (normObj === undefined) {
@@ -83,7 +84,8 @@ export function denormalize(
         break;
       }
 
-      const staleFields = staleMap[id];
+      keys.push(key);
+      const staleFields = staleMap[key];
 
       // If we've been here before we need to use the previously created response object
       if (Array.isArray(parentObjectOrArray)) {
@@ -185,6 +187,7 @@ export function denormalize(
   return {
     partial,
     stale,
-    data: !partial ? data : undefined
+    data: !partial ? data : undefined,
+    keys
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,20 +12,11 @@ export interface ResponseObject2 {
   readonly [key: string]: ResponseObjectFieldValue;
 }
 
-// export type ResponseObjectPrimitiveValue =
-//   | string
-//   | number
-//   | boolean
-//   | ResponseObjectPrimitiveArray;
-
-// export interface ResponseObjectPrimitiveArray
-//   extends ReadonlyArray<ResponseObjectPrimitiveValue> {}
-
 export type ResponseObjectFieldValue =
   | string
   | number
   | boolean
-  | ResponseObject
+  | ResponseObject2
   | ResponseObjectArray;
 
 export interface ResponseObjectArray
@@ -39,6 +30,7 @@ export interface DenormalizationResult {
   readonly data: RootFields | undefined;
   readonly partial: boolean;
   readonly stale: boolean;
+  readonly keys: ReadonlyArray<string>;
 }
 
 export interface FragmentMap {

--- a/test/denormalize-test-data.ts
+++ b/test/denormalize-test-data.ts
@@ -1,4 +1,4 @@
 import { loadTests } from "./test-data-utils";
-import { DenormalizeOneTest } from "./denormalize-test-def";
+import { DenormalizeTestDef } from "./denormalize-test-def";
 
-export const tests = loadTests<DenormalizeOneTest>("denormalize-tests/");
+export const tests = loadTests<DenormalizeTestDef>("denormalize-tests/");

--- a/test/denormalize-test-def.ts
+++ b/test/denormalize-test-def.ts
@@ -3,7 +3,7 @@ import { NormMap } from "../src/norm-map";
 import { StaleMap } from "../src/stale";
 import { RootFields, Variables } from "../src/types";
 
-export interface DenormalizeOneTest {
+export interface DenormalizeTestDef {
   readonly name: string;
   readonly only?: boolean;
   readonly skip?: boolean;
@@ -14,4 +14,5 @@ export interface DenormalizeOneTest {
   readonly partial: boolean;
   readonly stale: boolean;
   readonly staleMap: StaleMap;
+  readonly keys: ReadonlyArray<string>;
 }

--- a/test/denormalize-tests/with-multiple-subtree-same-query-node.ts
+++ b/test/denormalize-tests/with-multiple-subtree-same-query-node.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { DenormalizeOneTest } from "../denormalize-test-def";
+import { DenormalizeTestDef } from "../denormalize-test-def";
 
-export const test: DenormalizeOneTest = {
+export const test: DenormalizeTestDef = {
   name: "with multiple subtree on same query node",
   query: gql`
     query TestQuery {
@@ -97,5 +97,6 @@ export const test: DenormalizeOneTest = {
       __typename: "Commenter",
       name: "olle"
     }
-  }
+  },
+  keys: ["ROOT_QUERY", "Post;123", "Author;1", "Comment;1", "Commenter;1"]
 };

--- a/test/denormalize-tests/with-partial-false.ts
+++ b/test/denormalize-tests/with-partial-false.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { DenormalizeOneTest } from "../denormalize-test-def";
+import { DenormalizeTestDef } from "../denormalize-test-def";
 
-export const test: DenormalizeOneTest = {
+export const test: DenormalizeTestDef = {
   name: "with partial false",
   query: gql`
     query TestQuery {
@@ -56,5 +56,6 @@ export const test: DenormalizeOneTest = {
       comments: null
     },
     "Author;1": { id: "1", __typename: "Author", name: "Paul" }
-  }
+  },
+  keys: ["ROOT_QUERY", "Post;123", "Author;1"]
 };

--- a/test/denormalize-tests/with-partial-true-scalar.ts
+++ b/test/denormalize-tests/with-partial-true-scalar.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { DenormalizeOneTest } from "../denormalize-test-def";
+import { DenormalizeTestDef } from "../denormalize-test-def";
 
-export const test: DenormalizeOneTest = {
+export const test: DenormalizeTestDef = {
   name: "with partial scalar true",
   query: gql`
     query TestQuery {
@@ -24,5 +24,6 @@ export const test: DenormalizeOneTest = {
       id: "123",
       __typename: "Post"
     }
-  }
+  },
+  keys: ["ROOT_QUERY", "Post;123"]
 };

--- a/test/denormalize-tests/with-partial-true.ts
+++ b/test/denormalize-tests/with-partial-true.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { DenormalizeOneTest } from "../denormalize-test-def";
+import { DenormalizeTestDef } from "../denormalize-test-def";
 
-export const test: DenormalizeOneTest = {
+export const test: DenormalizeTestDef = {
   name: "with partial true",
   query: gql`
     query TestQuery {
@@ -41,5 +41,6 @@ export const test: DenormalizeOneTest = {
       title: "My awesome blog post",
       comments: null
     }
-  }
+  },
+  keys: ["ROOT_QUERY", "Post;123"]
 };

--- a/test/denormalize-tests/with-stale-false.ts
+++ b/test/denormalize-tests/with-stale-false.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { DenormalizeOneTest } from "../denormalize-test-def";
+import { DenormalizeTestDef } from "../denormalize-test-def";
 
-export const test: DenormalizeOneTest = {
+export const test: DenormalizeTestDef = {
   name: "with stale false",
   query: gql`
     query TestQuery {
@@ -62,5 +62,6 @@ export const test: DenormalizeOneTest = {
       comments: null
     },
     "Author;1": { id: "1", __typename: "Author", name: "Paul" }
-  }
+  },
+  keys: ["ROOT_QUERY", "Post;123", "Author;1"]
 };

--- a/test/denormalize-tests/with-stale-true.ts
+++ b/test/denormalize-tests/with-stale-true.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { DenormalizeOneTest } from "../denormalize-test-def";
+import { DenormalizeTestDef } from "../denormalize-test-def";
 
-export const test: DenormalizeOneTest = {
+export const test: DenormalizeTestDef = {
   name: "with stale true",
   query: gql`
     query TestQuery {
@@ -62,5 +62,6 @@ export const test: DenormalizeOneTest = {
       comments: null
     },
     "Author;1": { id: "1", __typename: "Author", name: "Paul" }
-  }
+  },
+  keys: ["ROOT_QUERY", "Post;123", "Author;1"]
 };

--- a/test/denormalize.test.ts
+++ b/test/denormalize.test.ts
@@ -25,6 +25,7 @@ describe("denormalize() with specialized test data", () => {
       expect(actual.data).toEqual(item.data);
       expect(actual.partial).toBe(!!item.partial);
       expect(actual.stale).toBe(!!item.stale);
+      expect(actual.keys).toEqual(item.keys);
       done();
     });
   });

--- a/test/shared-test-data.ts
+++ b/test/shared-test-data.ts
@@ -1,4 +1,4 @@
 import { loadTests } from "./test-data-utils";
-import { OneTest } from "./shared-test-def";
+import { SharedTestDef } from "./shared-test-def";
 
-export const tests = loadTests<OneTest>("shared-tests/");
+export const tests = loadTests<SharedTestDef>("shared-tests/");

--- a/test/shared-test-def.ts
+++ b/test/shared-test-def.ts
@@ -2,7 +2,7 @@ import * as GraphQL from "graphql";
 import { NormMap } from "../src/norm-map";
 import { Variables, RootFields } from "../src/types";
 
-export interface OneTest {
+export interface SharedTestDef {
   readonly name: string;
   readonly only?: boolean;
   readonly skip?: boolean;

--- a/test/shared-tests/query-with-array-of-string.ts
+++ b/test/shared-tests/query-with-array-of-string.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "query with array of strings",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/same-entity-twice-different-fields.ts
+++ b/test/shared-tests/same-entity-twice-different-fields.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "same object twice in response but with different fields",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/simple.ts
+++ b/test/shared-tests/simple.ts
@@ -1,9 +1,9 @@
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import gql from "graphql-tag";
 import { standardResponse } from "../shared-data/standard-response";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "simple",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-alias.ts
+++ b/test/shared-tests/with-alias.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with alias",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-array-of-string.ts
+++ b/test/shared-tests/with-array-of-string.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with array of String",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-deep-null-values.ts
+++ b/test/shared-tests/with-deep-null-values.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with deep null values",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-include-literal-false.ts
+++ b/test/shared-tests/with-include-literal-false.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip literal true",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-include-literal-true.ts
+++ b/test/shared-tests/with-include-literal-true.ts
@@ -1,9 +1,9 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip literal false",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-include-variable-false.ts
+++ b/test/shared-tests/with-include-variable-false.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip variable true",
   query: gql`
     query TestQuery($noPosts: Boolean!) {

--- a/test/shared-tests/with-include-variable-true.ts
+++ b/test/shared-tests/with-include-variable-true.ts
@@ -1,9 +1,9 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip variable false",
   query: gql`
     query TestQuery($noPosts: Boolean!) {

--- a/test/shared-tests/with-inline-fragments.ts
+++ b/test/shared-tests/with-inline-fragments.ts
@@ -1,9 +1,9 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with inline fragments",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-missing-id.ts
+++ b/test/shared-tests/with-missing-id.ts
@@ -1,11 +1,11 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
 const fallbackId1 = 'ROOT_QUERY.posts.0.comments({"a":{"b":"1","c":"asd"}}).0';
 const fallbackId2 = 'ROOT_QUERY.posts.0.comments({"a":{"b":"1","c":"asd"}}).1';
 const fallbackId3 = "ROOT_QUERY.testNode";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   // only: true,
   name: "with missing id",
   query: gql`

--- a/test/shared-tests/with-named-fragments.ts
+++ b/test/shared-tests/with-named-fragments.ts
@@ -1,9 +1,9 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with named fragments",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-nested-array-of-entities.ts
+++ b/test/shared-tests/with-nested-array-of-entities.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with nested arrays of objects",
   // only: true,
   // skip: true,

--- a/test/shared-tests/with-nested-array-of-strings.ts
+++ b/test/shared-tests/with-nested-array-of-strings.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with nested array of String",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-null-object.ts
+++ b/test/shared-tests/with-null-object.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with null object",
   query: gql`
     query TestQuery($postIds: [ID!]!) {

--- a/test/shared-tests/with-null-values.ts
+++ b/test/shared-tests/with-null-values.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with null values",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-object-and-null-in-array.ts
+++ b/test/shared-tests/with-object-and-null-in-array.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with object and null in array",
   query: gql`
     query TestQuery($postIds: [ID!]!) {

--- a/test/shared-tests/with-reserved-words.ts
+++ b/test/shared-tests/with-reserved-words.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with reserved keywords",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-skip-literal-false.ts
+++ b/test/shared-tests/with-skip-literal-false.ts
@@ -1,9 +1,9 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip literal false",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-skip-literal-true.ts
+++ b/test/shared-tests/with-skip-literal-true.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip literal true",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-skip-variable-false.ts
+++ b/test/shared-tests/with-skip-variable-false.ts
@@ -1,9 +1,9 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 import { standardNormMap } from "../shared-data/standard-norm-map";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip variable false",
   query: gql`
     query TestQuery($noPosts: Boolean!) {

--- a/test/shared-tests/with-skip-variable-true.ts
+++ b/test/shared-tests/with-skip-variable-true.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with skip variable true",
   query: gql`
     query TestQuery($noPosts: Boolean!) {

--- a/test/shared-tests/with-variables-simple-boolean-external-2.ts
+++ b/test/shared-tests/with-variables-simple-boolean-external-2.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with variables simple boolean external 2",
   query: gql`
     query TestQuery($a: Boolean) {

--- a/test/shared-tests/with-variables-simple-boolean-external.ts
+++ b/test/shared-tests/with-variables-simple-boolean-external.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with variables simple boolean external",
   query: gql`
     query TestQuery($a: Boolean) {

--- a/test/shared-tests/with-variables-simple-boolean.ts
+++ b/test/shared-tests/with-variables-simple-boolean.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with variables simple boolean",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-variables-simple-int.ts
+++ b/test/shared-tests/with-variables-simple-int.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with variables simple int",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-variables-simple-list.ts
+++ b/test/shared-tests/with-variables-simple-list.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with variables simple list",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-variables-simple-nested-object.ts
+++ b/test/shared-tests/with-variables-simple-nested-object.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with variables simple nested object",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-variables-simple-object.ts
+++ b/test/shared-tests/with-variables-simple-object.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
-import { OneTest } from "../shared-test-def";
+import { SharedTestDef } from "../shared-test-def";
 import { standardResponse } from "../shared-data/standard-response";
 
-export const test: OneTest = {
+export const test: SharedTestDef = {
   name: "with variables simple object",
   query: gql`
     query TestQuery {


### PR DESCRIPTION
Fixes #30.

This PR will add the keys of the normalized objects used during denormalization to the output of denormalize().