### PR TITLE
Generate fallback ID from parent ID and field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Genearate fallback IDs using the nearest parent as base. See issue [#27](https://github.com/dividab/graphql-norm/issues/27) and PR [#41](https://github.com/dividab/graphql-norm/pull/41).
+
 ### Removed
 
 - Removed staleness checking from denormalize(). See issue [#38](https://github.com/dividab/graphql-norm/issues/38) and PR [#40](https://github.com/dividab/graphql-norm/pull/40).

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -114,7 +114,7 @@ export function normalize(
               responseFieldValue,
               //path + "." + normFieldName
               // Use the current key plus fieldname as fallback id
-              keyOrNewParentArray + ";" + normFieldName
+              keyOrNewParentArray + "." + normFieldName
             ]);
           } else {
             // This field is a primitive (not a array of normalized objects or a single normalized object)

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -30,7 +30,7 @@ type StackWorkItem = [
   FieldNodeWithSelectionSet,
   ParentNormObjOrArray | undefined /*parentNormObj*/,
   ResponseObjectOrArray,
-  string
+  string // FallbackId
 ];
 
 /**
@@ -68,7 +68,7 @@ export function normalize(
       fieldNode,
       parentNormObjOrArray,
       responseObjectOrArray,
-      path
+      fallbackId
     ] = stack.pop()!;
 
     const expandedSelections = expandFragments(
@@ -84,7 +84,7 @@ export function normalize(
       // console.log("responseObject", responseObject);
       const objectToIdResult = getObjectIdToUse(responseObject);
       keyOrNewParentArray =
-        objectToIdResult !== undefined ? objectToIdResult : path;
+        objectToIdResult !== undefined ? objectToIdResult : fallbackId;
       // Get or create normalized object
       let normObj = normMap[keyOrNewParentArray];
       if (!normObj) {
@@ -114,6 +114,7 @@ export function normalize(
               normObj,
               responseFieldValue,
               //path + "." + normFieldName
+              // Use the current key plus fieldname as fallback id
               keyOrNewParentArray + ";" + normFieldName
             ]);
           } else {
@@ -130,7 +131,7 @@ export function normalize(
           fieldNode,
           keyOrNewParentArray,
           responseArray[i],
-          path + "." + i.toString()
+          fallbackId + "." + i.toString()
         ]);
       }
     }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -83,8 +83,7 @@ export function normalize(
       const responseObject = responseObjectOrArray as ResponseObject;
       // console.log("responseObject", responseObject);
       const objectToIdResult = getObjectIdToUse(responseObject);
-      keyOrNewParentArray =
-        objectToIdResult !== undefined ? objectToIdResult : fallbackId;
+      keyOrNewParentArray = objectToIdResult ? objectToIdResult : fallbackId;
       // Get or create normalized object
       let normObj = normMap[keyOrNewParentArray];
       if (!normObj) {

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -113,7 +113,8 @@ export function normalize(
               field as FieldNodeWithSelectionSet,
               normObj,
               responseFieldValue,
-              path + "." + normFieldName
+              //path + "." + normFieldName
+              keyOrNewParentArray + ";" + normFieldName
             ]);
           } else {
             // This field is a primitive (not a array of normalized objects or a single normalized object)

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -21,15 +21,13 @@ describe("merge()", () => {
         }
       `,
       response: {
-        data: {
-          user: {
-            id: "123",
-            __typename: "User",
-            address: {
-              __typename: "Address",
-              city: "Los Leones",
-              region: "Miramar"
-            }
+        user: {
+          id: "123",
+          __typename: "User",
+          address: {
+            __typename: "Address",
+            city: "Los Leones",
+            region: "Miramar"
           }
         }
       }
@@ -51,30 +49,27 @@ describe("merge()", () => {
         }
       `,
       response: {
-        data: {
-          users: [
-            {
-              id: "123",
-              __typename: "User",
-              address: {
-                __typename: "Address",
-                city: "Los Leones",
-                region: "Miramar"
-              }
+        users: [
+          {
+            id: "123",
+            __typename: "User",
+            address: {
+              __typename: "Address",
+              city: "Los Leones",
+              region: "Miramar"
             }
-          ]
-        }
+          }
+        ]
       }
     };
 
-    const normMapA = normalize(itemA.query, {}, itemA.response.data);
-    const normMapB = normalize(itemB.query, {}, itemB.response.data);
+    const normMapA = normalize(itemA.query, {}, itemA.response);
+    const normMapB = normalize(itemB.query, {}, itemB.response);
     const mergedNormMap = merge(normMapA, normMapB);
     const denormalizedResult = denormalize(itemA.query, {}, mergedNormMap);
     expect(denormalizedResult.partial).toBe(false);
   });
 
-  /*
   // When a value-object (an object with no ID, owned by it's parent) is
   // used, you would expect it to be merged like any other.
   test("partial value objects", () => {
@@ -93,14 +88,12 @@ describe("merge()", () => {
         }
       `,
       response: {
-        data: {
-          user: {
-            id: "123",
-            __typename: "User",
-            address: {
-              __typename: "Address",
-              city: "Los Leones"
-            }
+        user: {
+          id: "123",
+          __typename: "User",
+          address: {
+            __typename: "Address",
+            city: "Los Leones"
           }
         }
       }
@@ -121,18 +114,16 @@ describe("merge()", () => {
         }
       `,
       response: {
-        data: {
-          users: [
-            {
-              id: "123",
-              __typename: "User",
-              address: {
-                __typename: "Address",
-                region: "Miramar"
-              }
+        users: [
+          {
+            id: "123",
+            __typename: "User",
+            address: {
+              __typename: "Address",
+              region: "Miramar"
             }
-          ]
-        }
+          }
+        ]
       }
     };
 
@@ -143,5 +134,4 @@ describe("merge()", () => {
 
     expect(denormalizedResult.partial).toBe(false);
   });
-*/
 });

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -2,7 +2,7 @@ import { normalize } from "../src/normalize";
 import { tests } from "./shared-test-data";
 import { onlySkip } from "./test-data-utils";
 
-describe.only("normalize() with shared test data", () => {
+describe("normalize() with shared test data", () => {
   onlySkip(tests).forEach(item => {
     test(item.name, () => {
       const actual = normalize(item.query, item.variables, item.data);

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -2,7 +2,7 @@ import { normalize } from "../src/normalize";
 import { tests } from "./shared-test-data";
 import { onlySkip } from "./test-data-utils";
 
-describe("normalize() with shared test data", () => {
+describe.only("normalize() with shared test data", () => {
   onlySkip(tests).forEach(item => {
     test(item.name, () => {
       const actual = normalize(item.query, item.variables, item.data);

--- a/test/shared-tests/with-missing-id.ts
+++ b/test/shared-tests/with-missing-id.ts
@@ -1,12 +1,11 @@
 import gql from "graphql-tag";
 import { SharedTestDef } from "../shared-test-def";
 
-const fallbackId1 = 'ROOT_QUERY.posts.0.comments({"a":{"b":"1","c":"asd"}}).0';
-const fallbackId2 = 'ROOT_QUERY.posts.0.comments({"a":{"b":"1","c":"asd"}}).1';
+const fallbackId1 = 'Post;123.comments({"a":{"b":"1","c":"asd"}}).0';
+const fallbackId2 = 'Post;123.comments({"a":{"b":"1","c":"asd"}}).1';
 const fallbackId3 = "ROOT_QUERY.testNode";
 
 export const test: SharedTestDef = {
-  // only: true,
   name: "with missing id",
   query: gql`
     query TestQuery {

--- a/test/shared-tests/with-value-object-array.ts
+++ b/test/shared-tests/with-value-object-array.ts
@@ -2,7 +2,7 @@ import { SharedTestDef } from "../shared-test-def";
 import gql from "graphql-tag";
 
 export const test: SharedTestDef = {
-  name: "with value object",
+  name: "with value object array",
   only: true,
   query: gql`
     query TestQuery {
@@ -14,7 +14,7 @@ export const test: SharedTestDef = {
           __typename
           name
         }
-        header {
+        headers {
           title
           subtitle
         }
@@ -40,10 +40,20 @@ export const test: SharedTestDef = {
           __typename: "Author",
           name: "Paul"
         },
-        header: {
-          title: "My awesome blog post",
-          subtitle: "This is the best post ever"
-        },
+        headers: [
+          {
+            title: "My awesome blog post",
+            subtitle: "This is the best post ever"
+          },
+          {
+            title: "Alternate awesomeness",
+            subtitle: "Never better"
+          },
+          {
+            title: "Also another alternative",
+            subtitle: "Actually not that good"
+          }
+        ],
         comments: [
           {
             id: "324",
@@ -66,12 +76,24 @@ export const test: SharedTestDef = {
       id: "123",
       __typename: "Post",
       author: "Author;1",
-      header: "Post;123.header",
+      headers: [
+        "Post;123.headers.0",
+        "Post;123.headers.1",
+        "Post;123.headers.2"
+      ],
       comments: ["Comment;324"]
     },
-    "Post;123.header": {
+    "Post;123.headers.0": {
       title: "My awesome blog post",
       subtitle: "This is the best post ever"
+    },
+    "Post;123.headers.1": {
+      title: "Alternate awesomeness",
+      subtitle: "Never better"
+    },
+    "Post;123.headers.2": {
+      title: "Also another alternative",
+      subtitle: "Actually not that good"
     },
     "Author;1": { id: "1", __typename: "Author", name: "Paul" },
     "Comment;324": {

--- a/test/shared-tests/with-value-object-array.ts
+++ b/test/shared-tests/with-value-object-array.ts
@@ -3,7 +3,6 @@ import gql from "graphql-tag";
 
 export const test: SharedTestDef = {
   name: "with value object array",
-  only: true,
   query: gql`
     query TestQuery {
       posts {

--- a/test/shared-tests/with-value-object-nested-parents.ts
+++ b/test/shared-tests/with-value-object-nested-parents.ts
@@ -2,7 +2,7 @@ import { SharedTestDef } from "../shared-test-def";
 import gql from "graphql-tag";
 
 export const test: SharedTestDef = {
-  name: "with value object",
+  name: "with value object nested parents",
   query: gql`
     query TestQuery {
       posts {

--- a/test/shared-tests/with-value-object-nested-parents.ts
+++ b/test/shared-tests/with-value-object-nested-parents.ts
@@ -1,0 +1,87 @@
+import { SharedTestDef } from "../shared-test-def";
+import gql from "graphql-tag";
+
+export const test: SharedTestDef = {
+  name: "with value object",
+  query: gql`
+    query TestQuery {
+      posts {
+        id
+        __typename
+        author {
+          id
+          __typename
+          name
+        }
+        title
+        comments {
+          id
+          __typename
+          commenter {
+            id
+            __typename
+            name
+            address {
+              street
+              town
+            }
+          }
+        }
+      }
+    }
+  `,
+  data: {
+    posts: [
+      {
+        id: "123",
+        __typename: "Post",
+        author: {
+          id: "1",
+          __typename: "Author",
+          name: "Paul"
+        },
+        title: "My awesome blog post",
+        comments: [
+          {
+            id: "324",
+            __typename: "Comment",
+            commenter: {
+              id: "2",
+              __typename: "Author",
+              name: "Nicole",
+              address: {
+                street: "Nicolestreet",
+                town: "Nicoletown"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  normMap: {
+    ROOT_QUERY: {
+      posts: ["Post;123"]
+    },
+    "Post;123": {
+      id: "123",
+      __typename: "Post",
+      author: "Author;1",
+      title: "My awesome blog post",
+      comments: ["Comment;324"]
+    },
+    "Author;1": { id: "1", __typename: "Author", name: "Paul" },
+    "Comment;324": {
+      id: "324",
+      __typename: "Comment",
+      commenter: "Author;2"
+    },
+    "Author;2": {
+      id: "2",
+      __typename: "Author",
+      name: "Nicole",
+      address: "Author;2.address"
+    },
+    "Author;2.address": { street: "Nicolestreet", town: "Nicoletown" }
+  }
+};

--- a/test/shared-tests/with-value-object-nested.ts
+++ b/test/shared-tests/with-value-object-nested.ts
@@ -1,0 +1,116 @@
+import { SharedTestDef } from "../shared-test-def";
+import gql from "graphql-tag";
+
+export const test: SharedTestDef = {
+  name: "with value object nested",
+  query: gql`
+    query TestQuery {
+      posts {
+        id
+        __typename
+        author {
+          id
+          __typename
+          name
+        }
+        headers {
+          title
+          subheader {
+            title
+          }
+        }
+        comments {
+          id
+          __typename
+          commenter {
+            id
+            __typename
+            name
+          }
+        }
+      }
+    }
+  `,
+  data: {
+    posts: [
+      {
+        id: "123",
+        __typename: "Post",
+        author: {
+          id: "1",
+          __typename: "Author",
+          name: "Paul"
+        },
+        headers: [
+          {
+            title: "My awesome blog post",
+            subheader: { title: "This is the best post ever" }
+          },
+          {
+            title: "Alternate awesomeness",
+            subheader: { title: "Never better" }
+          },
+          {
+            title: "Also another alternative",
+            subheader: { title: "Actually not that good" }
+          }
+        ],
+        comments: [
+          {
+            id: "324",
+            __typename: "Comment",
+            commenter: {
+              id: "2",
+              __typename: "Author",
+              name: "Nicole"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  normMap: {
+    ROOT_QUERY: {
+      posts: ["Post;123"]
+    },
+    "Post;123": {
+      id: "123",
+      __typename: "Post",
+      author: "Author;1",
+      headers: [
+        "Post;123.headers.0",
+        "Post;123.headers.1",
+        "Post;123.headers.2"
+      ],
+      comments: ["Comment;324"]
+    },
+    "Post;123.headers.0": {
+      title: "My awesome blog post",
+      subheader: "Post;123.headers.0.subheader"
+    },
+    "Post;123.headers.0.subheader": {
+      title: "This is the best post ever"
+    },
+    "Post;123.headers.1": {
+      title: "Alternate awesomeness",
+      subheader: "Post;123.headers.1.subheader"
+    },
+    "Post;123.headers.1.subheader": {
+      title: "Never better"
+    },
+    "Post;123.headers.2": {
+      title: "Also another alternative",
+      subheader: "Post;123.headers.2.subheader"
+    },
+    "Post;123.headers.2.subheader": {
+      title: "Actually not that good"
+    },
+    "Author;1": { id: "1", __typename: "Author", name: "Paul" },
+    "Comment;324": {
+      id: "324",
+      __typename: "Comment",
+      commenter: "Author;2"
+    },
+    "Author;2": { id: "2", __typename: "Author", name: "Nicole" }
+  }
+};

--- a/test/shared-tests/with-value-object-no-parents.ts
+++ b/test/shared-tests/with-value-object-no-parents.ts
@@ -2,7 +2,7 @@ import { SharedTestDef } from "../shared-test-def";
 import gql from "graphql-tag";
 
 export const test: SharedTestDef = {
-  name: "with value object",
+  name: "with value object no parents",
   query: gql`
     query TestQuery {
       address {

--- a/test/shared-tests/with-value-object-no-parents.ts
+++ b/test/shared-tests/with-value-object-no-parents.ts
@@ -1,0 +1,36 @@
+import { SharedTestDef } from "../shared-test-def";
+import gql from "graphql-tag";
+
+export const test: SharedTestDef = {
+  name: "with value object",
+  query: gql`
+    query TestQuery {
+      address {
+        street
+      }
+      posts {
+        title
+      }
+    }
+  `,
+  data: {
+    address: { street: "mainstreet" },
+    posts: [
+      {
+        title: "My awesome blog post"
+      },
+      {
+        title: "My awesome blog post2"
+      }
+    ]
+  },
+  normMap: {
+    ROOT_QUERY: {
+      address: "ROOT_QUERY.address",
+      posts: ["ROOT_QUERY.posts.0", "ROOT_QUERY.posts.1"]
+    },
+    "ROOT_QUERY.address": { street: "mainstreet" },
+    "ROOT_QUERY.posts.0": { title: "My awesome blog post" },
+    "ROOT_QUERY.posts.1": { title: "My awesome blog post2" }
+  }
+};

--- a/test/shared-tests/with-value-object-parent-with-variables.ts
+++ b/test/shared-tests/with-value-object-parent-with-variables.ts
@@ -1,0 +1,58 @@
+import gql from "graphql-tag";
+import { SharedTestDef } from "../shared-test-def";
+
+export const test: SharedTestDef = {
+  name: "with value object parent with variables",
+  query: gql`
+    query TestQuery {
+      posts {
+        id
+        __typename
+        author {
+          id
+          __typename
+          name
+        }
+        title
+        comments(a: 1) {
+          body
+        }
+      }
+    }
+  `,
+  data: {
+    posts: [
+      {
+        id: "123",
+        __typename: "Post",
+        author: {
+          id: "1",
+          __typename: "Author",
+          name: "Paul"
+        },
+        title: "My awesome blog post",
+        comments: [
+          {
+            body: "The comment"
+          }
+        ]
+      }
+    ]
+  },
+  normMap: {
+    ROOT_QUERY: {
+      posts: ["Post;123"]
+    },
+    "Post;123": {
+      id: "123",
+      __typename: "Post",
+      author: "Author;1",
+      title: "My awesome blog post",
+      'comments({"a":"1"})': ['Post;123.comments({"a":"1"}).0']
+    },
+    "Author;1": { id: "1", __typename: "Author", name: "Paul" },
+    'Post;123.comments({"a":"1"}).0': {
+      body: "The comment"
+    }
+  }
+};

--- a/test/shared-tests/with-value-object.ts
+++ b/test/shared-tests/with-value-object.ts
@@ -1,0 +1,84 @@
+import { SharedTestDef } from "../shared-test-def";
+import gql from "graphql-tag";
+
+export const test: SharedTestDef = {
+  name: "with value object",
+  only: true,
+  query: gql`
+    query TestQuery {
+      posts {
+        id
+        __typename
+        author {
+          id
+          __typename
+          name
+        }
+        header {
+          title
+          subtitle
+        }
+        comments {
+          id
+          __typename
+          commenter {
+            id
+            __typename
+            name
+          }
+        }
+      }
+    }
+  `,
+  data: {
+    posts: [
+      {
+        id: "123",
+        __typename: "Post",
+        author: {
+          id: "1",
+          __typename: "Author",
+          name: "Paul"
+        },
+        header: {
+          title: "My awesome blog post",
+          subtitle: "This is the best post ever"
+        },
+        comments: [
+          {
+            id: "324",
+            __typename: "Comment",
+            commenter: {
+              id: "2",
+              __typename: "Author",
+              name: "Nicole"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  normMap: {
+    ROOT_QUERY: {
+      posts: ["Post;123"]
+    },
+    "Post;123": {
+      id: "123",
+      __typename: "Post",
+      author: "Author;1",
+      header: "Post;123;header",
+      comments: ["Comment;324"]
+    },
+    "Post;123;header": {
+      title: "My awesome blog post",
+      subtitle: "This is the best post ever"
+    },
+    "Author;1": { id: "1", __typename: "Author", name: "Paul" },
+    "Comment;324": {
+      id: "324",
+      __typename: "Comment",
+      commenter: "Author;2"
+    },
+    "Author;2": { id: "2", __typename: "Author", name: "Nicole" }
+  }
+};

--- a/test/shared-tests/with-value-object.ts
+++ b/test/shared-tests/with-value-object.ts
@@ -3,7 +3,6 @@ import gql from "graphql-tag";
 
 export const test: SharedTestDef = {
   name: "with value object",
-  only: true,
   query: gql`
     query TestQuery {
       posts {


### PR DESCRIPTION
Fixes #27.

The goal of this PR is to have fallback IDs generated from the closest parent that has an ID or ROOT_QUERY if there is no parent with ID.