### PR TITLE
Return fist cache miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/graphql-norm/compare/v1.2.0...master)
 
+- If denormalize() could not be fulfill a query, data will be `undefined` and `fields` will contain the first field that could not be resolved.
+
 ## [1.2.0](https://github.com/dividab/graphql-norm/compare/v1.1.0...v1.2.0) - 2019-10-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The denormalize() function takes a GraphQL query with associated variables, and 
 This function returns an object with information about the denormalization result. The following properties are available on the returned object:
 
 - **data**: This is the data for the query as it would have been returned from a GraphQL serverl, or `undefined` is the query could not be completely fulfilled from the data in `normMap`.
-- **fields**: An object where each property is an normlized object key, and the value is a `Set` of used fields. This can be useful for tracking which key/fields will affect this query data. If an tuple of this object and the data is stored, each time a new normalized result is merged a cache we can check if the new normalized data being merged contains any of the keys/fields of this query then it is affected by the merge, otherwise not. This is similar to the approach used [by relay](https://relay.dev/docs/en/thinking-in-graphql#achieving-view-consistency) for tracking changes.
+- **fields**: An object where each property is an normlized object key, and the value is a `Set` of used fields. This can be useful for tracking which key/fields will affect this query data. If an tuple of this object and the data is stored, each time a new normalized result is merged a cache we can check if the new normalized data being merged contains any of the keys/fields of this query then it is affected by the merge, otherwise not. This is similar to the approach used [by relay](https://relay.dev/docs/en/thinking-in-graphql#achieving-view-consistency) for tracking changes. If the query could not be fulfilled from cache, data will be `undefined` and `fields` will contain the first field that could not be resolved.
 
 ### merge()
 

--- a/src/denormalize.ts
+++ b/src/denormalize.ts
@@ -55,7 +55,6 @@ export function denormalize(
 
   const stack: Array<StackWorkItem> = [];
   const response = {};
-  // let partial = false;
   const usedFieldsMap: {
     // eslint-disable-next-line
     [key: string]: Set<string>;
@@ -98,8 +97,6 @@ export function denormalize(
 
       // Does not exist in normalized map. We can't fully resolve query
       if (normObj === undefined) {
-        // partial = true;
-        // break;
         return {
           data: undefined,
           fields: { [parentNormKey]: new Set([fieldNameInParent]) }
@@ -165,7 +162,6 @@ export function denormalize(
                 (field.alias && field.alias.value) || field.name.value
               ] = normObjValue;
             } else {
-              // partial = true;
               return {
                 data: undefined,
                 fields: { [key]: new Set([fieldName]) }
@@ -220,7 +216,6 @@ export function denormalize(
   const data = (response as GraphQLResponse).data;
 
   return {
-    // data: !partial ? data : undefined,
     data: data,
     fields: usedFieldsMap
   };

--- a/src/denormalize.ts
+++ b/src/denormalize.ts
@@ -53,7 +53,7 @@ export function denormalize(
 
   const stack: Array<StackWorkItem> = [];
   const response = {};
-  let partial = false;
+  // let partial = false;
   const usedFieldsMap: {
     // eslint-disable-next-line
     [key: string]: Set<string>;
@@ -87,8 +87,12 @@ export function denormalize(
 
       // Does not exist in normalized map. We can't fully resolve query
       if (normObj === undefined) {
-        partial = true;
-        break;
+        // partial = true;
+        // break;
+        return {
+          data: undefined,
+          fields: { [key]: new Set() }
+        };
       }
 
       let usedFields = usedFieldsMap[key];
@@ -124,13 +128,13 @@ export function denormalize(
           : true;
         if (include) {
           // Build key according to any arguments
-          const key =
+          const fieldName =
             field.arguments && field.arguments.length > 0
               ? fieldNameWithArguments(field, variables)
               : field.name.value;
           // Add this to used fields
-          usedFields.add(key);
-          const normObjValue = normObj[key];
+          usedFields.add(fieldName);
+          const normObjValue = normObj[fieldName];
           if (normObjValue !== null && field.selectionSet) {
             // Put a work-item on the stack to build this field and set it on the response object
             stack.push([
@@ -148,7 +152,11 @@ export function denormalize(
                 (field.alias && field.alias.value) || field.name.value
               ] = normObjValue;
             } else {
-              partial = true;
+              // partial = true;
+              return {
+                data: undefined,
+                fields: { [key]: new Set([fieldName]) }
+              };
             }
           }
         }
@@ -197,7 +205,8 @@ export function denormalize(
   const data = (response as GraphQLResponse).data;
 
   return {
-    data: !partial ? data : undefined,
+    // data: !partial ? data : undefined,
+    data: data,
     fields: usedFieldsMap
   };
 }

--- a/test/denormalize-tests/with-incomplete.ts
+++ b/test/denormalize-tests/with-incomplete.ts
@@ -40,8 +40,6 @@ export const test: DenormalizeTestDef = {
     }
   },
   fields: {
-    // ROOT_QUERY: ["posts"],
-    // "Post:123": ["id", "__typename", "author", "title", "comments"]
     "Post:123": ["author"]
   }
 };

--- a/test/denormalize-tests/with-incomplete.ts
+++ b/test/denormalize-tests/with-incomplete.ts
@@ -40,7 +40,8 @@ export const test: DenormalizeTestDef = {
     }
   },
   fields: {
-    ROOT_QUERY: ["posts"],
-    "Post:123": ["id", "__typename", "author", "title", "comments"]
+    // ROOT_QUERY: ["posts"],
+    // "Post:123": ["id", "__typename", "author", "title", "comments"]
+    "Post:123": ["author"]
   }
 };

--- a/test/denormalize-tests/with-scalar-incomplete.ts
+++ b/test/denormalize-tests/with-scalar-incomplete.ts
@@ -22,6 +22,5 @@ export const test: DenormalizeTestDef = {
       __typename: "Post"
     }
   },
-  // fields: { ROOT_QUERY: ["posts"], "Post:123": ["id", "__typename", "title"] }
   fields: { "Post:123": ["title"] }
 };

--- a/test/denormalize-tests/with-scalar-incomplete.ts
+++ b/test/denormalize-tests/with-scalar-incomplete.ts
@@ -22,5 +22,6 @@ export const test: DenormalizeTestDef = {
       __typename: "Post"
     }
   },
-  fields: { ROOT_QUERY: ["posts"], "Post:123": ["id", "__typename", "title"] }
+  // fields: { ROOT_QUERY: ["posts"], "Post:123": ["id", "__typename", "title"] }
+  fields: { "Post:123": ["title"] }
 };

--- a/test/denormalize.test.ts
+++ b/test/denormalize.test.ts
@@ -17,6 +17,7 @@ describe("denormalize() with specialized test data", () => {
   onlySkip(TestDataDenormalization.tests).forEach(item => {
     test(item.name, done => {
       const actual = denormalize(item.query, item.variables, item.normMap);
+      console.log("actual.fields", actual.fields);
       expect(actual.data).toEqual(item.data);
       expect(actual.fields).toEqual(
         Object.fromEntries(

--- a/test/denormalize.test.ts
+++ b/test/denormalize.test.ts
@@ -17,7 +17,6 @@ describe("denormalize() with specialized test data", () => {
   onlySkip(TestDataDenormalization.tests).forEach(item => {
     test(item.name, done => {
       const actual = denormalize(item.query, item.variables, item.normMap);
-      console.log("actual.fields", actual.fields);
       expect(actual.data).toEqual(item.data);
       expect(actual.fields).toEqual(
         Object.fromEntries(


### PR DESCRIPTION
When debugging why `denormalize()` returned `data` as `undefined` it is useful to know which field was missing from the cache. This PR will add functionality so `fields` in the result will indicate the first missing field in this case.