### PR TITLE
Include typescript source in npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/graphql-norm/compare/v1.2.0...master)
 
-- Include `src/` in the published package. See PR [#52](https://github.com/dividab/graphql-norm/pull/52) for more info.
+- Include typescript source from `src/` in published npm package. See PR [#52](https://github.com/dividab/graphql-norm/pull/52) for more info.
 
 ## [1.3.0](https://github.com/dividab/graphql-norm/compare/v1.2.0...v1.3.0) - 2019-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/graphql-norm/compare/v1.2.0...master)
 
+- Include `src/` in the published package. See PR [#52](https://github.com/dividab/graphql-norm/pull/52) for more info.
+
 ## [1.3.0](https://github.com/dividab/graphql-norm/compare/v1.2.0...v1.3.0) - 2019-10-15
 
 - If denormalize() could not be fulfill a query, data will be `undefined` and `fields` will contain the first field that could not be resolved.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "files": [
     "/lib",
     "/dist",
+    "/src",
     "package.json",
     "CHANGELOG.md",
     "LICENSE",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "../lib",
     "sourceMap": true,
     "declaration": true,
+    "declarationMap": true,
     "target": "es6",
     "module": "es6",
     "moduleResolution": "node",


### PR DESCRIPTION
This PR will include the typescript sources in `src/` in the published npm package. We were already including *.map files but when eg. webpack tried to load them the referenced typescript files in `src/` were not found so webpack emits a warning.

The choice is either to make a special production build without source maps and publish the *.js files without any sourcemap refrences, or include everything in the npm package. My reasoning here is that if we include everything it will be easier to get god stack traces and debug. 